### PR TITLE
feat(partials): add support for mustache partials

### DIFF
--- a/lib/src/dot_prompt.dart
+++ b/lib/src/dot_prompt.dart
@@ -1,3 +1,6 @@
+/// @docImport 'path_partial_resolver.dart';
+library;
+
 import 'dart:async';
 import 'dart:convert';
 
@@ -7,7 +10,6 @@ import 'package:yaml/yaml.dart';
 
 import 'dot_prompt_front_matter.dart';
 import 'partial_resolver.dart';
-import 'path_partial_resolver.dart';
 import 'utility.dart';
 
 /// Exception thrown when input data fails schema validation.

--- a/lib/src/partial_resolver.dart
+++ b/lib/src/partial_resolver.dart
@@ -1,0 +1,11 @@
+import 'package:mustache_template/mustache_template.dart';
+
+// ignore: unused_import
+import 'partial_resolver_web.dart'
+    if (dart.library.io) 'path_partial_resolver.dart';
+
+/// A class for resolving partials.
+abstract class DotPromptPartialResolver {
+  /// The resolver function.
+  Template? resolve(String name);
+}

--- a/lib/src/partial_resolver_web.dart
+++ b/lib/src/partial_resolver_web.dart
@@ -1,0 +1,3 @@
+// There is no default resolver for web.  You have to write a subclass of
+// DotPromptPartialResolver that resolves partials in the right way for your use
+// case.

--- a/lib/src/path_partial_resolver.dart
+++ b/lib/src/path_partial_resolver.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:mustache_template/mustache_template.dart';
+import 'package:path/path.dart' as path;
+
+import 'partial_resolver.dart';
+
+/// IO implementation of [DotPromptPartialResolver] that looks for partials in
+/// the given directories.
+class PathPartialResolver implements DotPromptPartialResolver {
+  /// Creates a new instance of [PathPartialResolver].
+  PathPartialResolver(List<Directory> partialPaths)
+    : _partialPaths = partialPaths;
+
+  final List<Directory> _partialPaths;
+
+  @override
+  Template? resolve(String name) {
+    if (_partialPaths.isEmpty) {
+      return null;
+    }
+
+    for (final partialDir in _partialPaths) {
+      // Look for .prompt file
+      var partialPath = path.join(partialDir.path, '_$name.prompt');
+      if (File(partialPath).existsSync()) {
+        final partialContent = File(partialPath).readAsStringSync();
+        final parts = partialContent.split('---');
+        var template = partialContent;
+        if (parts.length >= 2) {
+          template =
+              parts.length > 2 ? parts.sublist(2).join('---').trim() : '';
+        }
+        return Template(template, htmlEscapeValues: false);
+      }
+
+      // Look for .mustache file
+      partialPath = path.join(partialDir.path, '_$name.mustache');
+      if (File(partialPath).existsSync()) {
+        final partialContent = File(partialPath).readAsStringSync();
+        return Template(partialContent, htmlEscapeValues: false);
+      }
+    }
+
+    return null;
+  }
+}

--- a/test/partial_resolver_test.dart
+++ b/test/partial_resolver_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:dotprompt_dart/dotprompt_dart.dart';
+import 'package:dotprompt_dart/src/path_partial_resolver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PathPartialResolver', () {
+    late Directory tempDir;
+    late Directory partialsDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('dotprompt_test_');
+      partialsDir = Directory('${tempDir.path}/partials')..createSync();
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('resolves .prompt partial', () {
+      File('${partialsDir.path}/_my_partial.prompt').writeAsStringSync('''
+---
+name: my_partial
+---
+Hello from the prompt partial!
+''');
+
+      final resolver = PathPartialResolver([partialsDir]);
+      final template = resolver.resolve('my_partial');
+
+      expect(template, isNotNull);
+      expect(
+        template!.renderString({}),
+        equals('Hello from the prompt partial!'),
+      );
+    });
+
+    test('resolves .mustache partial', () {
+      File(
+        '${partialsDir.path}/_my_partial.mustache',
+      ).writeAsStringSync('Hello from the mustache partial!');
+
+      final resolver = PathPartialResolver([partialsDir]);
+      final template = resolver.resolve('my_partial');
+
+      expect(template, isNotNull);
+      expect(
+        template!.renderString({}),
+        equals('Hello from the mustache partial!'),
+      );
+    });
+
+    test('returns null for non-existent partial', () {
+      final resolver = PathPartialResolver([partialsDir]);
+      final template = resolver.resolve('non_existent');
+      expect(template, isNull);
+    });
+
+    test('DotPrompt renders template with partial', () {
+      const mainPromptContent = '''
+---
+name: main
+---
+Main content: {{> my_partial }}
+''';
+      File('${partialsDir.path}/_my_partial.prompt').writeAsStringSync('''
+---
+name: my_partial
+---
+Partial content.
+''');
+
+      final resolver = PathPartialResolver([partialsDir]);
+      final prompt = DotPrompt(mainPromptContent, partialResolver: resolver);
+      final output = prompt.render({}).trim();
+
+      expect(output, equals('Main content: Partial content.'));
+    });
+
+    test('DotPrompt.stream renders template with partial', () async {
+      final mainPromptFile = File('${tempDir.path}/main.prompt')
+        ..writeAsStringSync('''
+---
+name: main
+---
+Stream content: {{> my_partial }}
+''');
+      File('${partialsDir.path}/_my_partial.prompt').writeAsStringSync('''
+---
+name: my_partial
+---
+Stream partial.
+''');
+
+      final resolver = PathPartialResolver([partialsDir]);
+      final prompt = await DotPrompt.stream(
+        mainPromptFile.openRead(),
+        name: mainPromptFile.path,
+        partialResolver: resolver,
+      );
+      final output = prompt.render({}).trim();
+
+      expect(output, equals('Stream content: Stream partial.'));
+    });
+
+    test('handles nested partials', () {
+      const mainPromptContent = 'Main: {{> partial1 }}';
+      File(
+        '${partialsDir.path}/_partial1.prompt',
+      ).writeAsStringSync('P1: {{> partial2 }}');
+      File('${partialsDir.path}/_partial2.prompt').writeAsStringSync('P2');
+
+      final resolver = PathPartialResolver([partialsDir]);
+      final prompt = DotPrompt(mainPromptContent, partialResolver: resolver);
+      final output = prompt.render({}).trim();
+
+      expect(output, equals('Main: P1: P2'));
+    });
+    test('extracts only template content from partial', () {
+      const mainPromptContent = 'Main: {{> partial_with_front_matter }}';
+      File(
+        '${partialsDir.path}/_partial_with_front_matter.prompt',
+      ).writeAsStringSync('''
+---
+name: partial
+---
+This is the actual template content.
+''');
+
+      final resolver = PathPartialResolver([partialsDir]);
+      final prompt = DotPrompt(mainPromptContent, partialResolver: resolver);
+      final output = prompt.render({}).trim();
+
+      expect(output, equals('Main: This is the actual template content.'));
+    });
+  });
+}


### PR DESCRIPTION
# Description

Hi Chris!

I found myself needing this, so I figured I'd add it here.

This change introduces support for Mustache partials in `.prompt` files, allowing for reusable template snippets.

A new abstract class, `DotPromptPartialResolver`, has been added to provide a common interface for resolving partials. For applications with access to `dart:io`, a `PathPartialResolver` is provided, which can search for partial files (e.g., `_my_partial.prompt` or `_my_partial.mustache`) in a given list of directories.

The `DotPrompt` constructor now accepts an optional `partialResolver` to enable this functionality. The `README.md` has been updated to document this new feature, and comprehensive unit tests have been added to ensure its correctness.